### PR TITLE
Allow mapping to be declared, but binding happens inside plugin config

### DIFF
--- a/lua/strive/init.lua
+++ b/lua/strive/init.lua
@@ -607,7 +607,7 @@ function Plugin.new(spec)
     events = {}, -- Events to trigger loading
     filetypes = {}, -- Filetypes to trigger loading
     commands = {}, -- Commands to trigger loading
-    keys = {}, -- Keys to trigger loading
+    mappings = {}, -- Keys to trigger loading
 
     -- Configuration
     setup_opts = spec.setup or {}, -- Options for plugin setup()
@@ -924,9 +924,9 @@ end
 -- Set up lazy loading for specific keymaps
 function Plugin:keys(mappings)
   self.is_lazy = true
-  self.keys = type(mappings) ~= 'table' and { mappings } or mappings
+  self.mappings = type(mappings) ~= 'table' and { mappings } or mappings
 
-  for _, mapping in ipairs(self.keys) do
+  for _, mapping in ipairs(self.mappings) do
     local mode, lhs, rhs, opts
 
     if type(mapping) == 'table' then


### PR DESCRIPTION
- **Disambiguate field "keys" from method with the same name. The method "keys" raised an error that I was trying to call a table. I just renamed the field "keys" to "mappings'.**
- **Allow mapping to be created inside plugin setup, but still specified as a trigger to load the plugin.**
